### PR TITLE
update dependencies to be more permissive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,8 @@ build = "build.py"
 [tool.poetry.dependencies]
 python = ">=3.10"
 pyyaml = "^6.0.1"
+numpy = ">=1.22.4"
 pandas = "^2.2.2"
-numpy = "^2.0.0"
-matplotlib = "^3.8.4"
 ipython = "^8.22.1"
 
 [tool.poetry.urls]


### PR DESCRIPTION
since numpy is not actually being used for anything except type checking, it seems safe to be very permissive in the required version. I've put the minimum requirement at 1.22.4, which is the [minimum requirement for pandas 2.2.x](https://github.com/pandas-dev/pandas/blob/2.2.x/pyproject.toml)

matplotlib is also not being used so I've removed it.