### PR TITLE
Fix wheels so they install on Python 3.11+, drop two heavy deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,16 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
+# Never cancel a release in flight; a half-published run is worse than a slow one.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  # ── 1. Validate tag and extract version ──────────────────────────────
+  # ── 1. Resolve and validate the version ──────────────────────────────
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -24,19 +32,31 @@ jobs:
     steps:
       - name: Resolve version
         id: meta
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
-            echo "TestPyPI rehearsal: ${VERSION}"
+            VERSION="${INPUT_VERSION}"
           else
             if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
               echo "::error::A release must be triggered by a v* tag push."
               exit 1
             fi
             VERSION="${GITHUB_REF#refs/tags/v}"
-            echo "Release: ${VERSION}"
           fi
+
+          # Tolerate a v prefix typed into the dispatch box; poetry-core rejects it.
+          VERSION="${VERSION#v}"
+
+          # Also closes the injection path, since this value is interpolated
+          # into a sed expression downstream.
+          if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.\-]?[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '${VERSION}' is not a valid PEP 440 version."
+            exit 1
+          fi
+
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
 
   # ── 2. Run tests ─────────────────────────────────────────────────────
   test:
@@ -47,10 +67,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -63,7 +83,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          poetry build
+          poetry build -f wheel
           python -m pip install dist/*.whl
           python -m pip install pytest
 
@@ -104,20 +124,24 @@ jobs:
           - target: osx-universal
             plat: macosx_10_15_x86_64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
-      - name: Stamp version from tag
+      - name: Stamp version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.version }}"/' pyproject.toml
+          sed -i.bak "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
           rm -f pyproject.toml.bak
 
       - name: Install build tooling
-        run: python -m pip install --upgrade pip poetry wheel
+        # wheel is pinned: `wheel tags` below is the load-bearing step of this
+        # whole design, and a silent CLI change would break releases.
+        run: python -m pip install --upgrade pip poetry "wheel>=0.45,<1"
 
       - name: Fetch mmseqs binary for ${{ matrix.target }}
         env:
@@ -141,7 +165,7 @@ jobs:
           ls -l dist/
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-wheel-${{ strategy.job-index }}
           path: ./dist/*.whl
@@ -151,16 +175,18 @@ jobs:
     needs: [prepare, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
-      - name: Stamp version from tag
+      - name: Stamp version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.version }}"/' pyproject.toml
+          sed -i.bak "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
           rm -f pyproject.toml.bak
 
       - name: Install Poetry
@@ -170,41 +196,70 @@ jobs:
         run: poetry build --format sdist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-sdist
           path: dist/*.tar.gz
 
-  # ── 5. Smoke-test wheels on Pythons they were not built with ─────────
-  # This is the regression guard for the bug this pipeline shape exists to fix:
-  # wheels that only install on the interpreter that happened to build them.
+  # ── 5a. Smoke-test wheels on Pythons they were not built with ────────
+  # The regression guard for the bug this pipeline shape exists to fix: wheels
+  # that only install on the interpreter that happened to build them.
   # Deliberately does not check out the repo, so the source tree cannot shadow
   # the installed package.
+  #
+  # macOS x86_64 is absent because GitHub retired every Intel macOS runner
+  # (only macos-14/15/26, all arm64, remain). That wheel carries a binary
+  # byte-identical to the arm64 one - same universal2 tarball - so the payload
+  # is covered by the macos leg below; only its platform tag is unexercised.
   smoke-test:
     needs: [build-wheels]
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - runner: ubuntu-latest
+            python-version: "3.10"
+            wheel: "*manylinux1_x86_64*.whl"
+          - runner: ubuntu-latest
+            python-version: "3.13"
+            wheel: "*manylinux1_x86_64*.whl"
+          - runner: ubuntu-24.04-arm
+            python-version: "3.13"
+            wheel: "*manylinux2014_aarch64*.whl"
+          - runner: macos-latest
+            python-version: "3.13"
+            wheel: "*macosx_11_0_arm64*.whl"
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-wheel-*
           path: dist
           merge-multiple: true
 
-      - name: Install the manylinux x86_64 wheel and run mmseqs
+      - name: Install ${{ matrix.wheel }} and run mmseqs
+        env:
+          WHEEL_GLOB: ${{ matrix.wheel }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install dist/*manylinux*_x86_64.whl
-          python - <<'EOF'
+          # Fail loudly rather than silently installing the wrong one if a
+          # future tag change makes a pattern match two wheels.
+          count=$(find dist -maxdepth 1 -name "$WHEEL_GLOB" | wc -l)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected 1 wheel for '$WHEEL_GLOB', got $count"
+            find dist -maxdepth 1 -name "$WHEEL_GLOB"
+            exit 1
+          fi
+          WHEEL=$(find dist -maxdepth 1 -name "$WHEEL_GLOB")
+          echo "Installing $WHEEL on $(python -V)"
+          python -m pip install "$WHEEL"
+          python - <<'PY'
           import subprocess
           from pymmseqs.utils import get_mmseqs_binary
           binary = get_mmseqs_binary()
@@ -212,7 +267,60 @@ jobs:
           out = subprocess.run([binary, "version"], capture_output=True, text=True)
           print("mmseqs version:", out.stdout.strip())
           assert out.returncode == 0, out.stderr
-          EOF
+          PY
+
+  # ── 5b. Smoke-test the musl wheels ───────────────────────────────────
+  # Alpine runs via `docker run`, not a job-level `container:`. Actions cannot
+  # execute inside musl images (the Node the runner injects is glibc-linked),
+  # so a container job would fail before ever reaching pip.
+  smoke-test-musl:
+    needs: [build-wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            wheel: "*musllinux_1_2_x86_64*.whl"
+          - runner: ubuntu-24.04-arm
+            wheel: "*musllinux_1_2_aarch64*.whl"
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v8
+        with:
+          pattern: dist-wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: Write check script
+        run: |
+          cat > check.py <<'PY'
+          import subprocess
+          from pymmseqs.utils import get_mmseqs_binary
+          binary = get_mmseqs_binary()
+          print("resolved:", binary)
+          out = subprocess.run([binary, "version"], capture_output=True, text=True)
+          print("mmseqs version:", out.stdout.strip())
+          assert out.returncode == 0, out.stderr
+          PY
+
+      - name: Install ${{ matrix.wheel }} inside Alpine
+        env:
+          WHEEL_GLOB: ${{ matrix.wheel }}
+        run: |
+          count=$(find dist -maxdepth 1 -name "$WHEEL_GLOB" | wc -l)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected 1 wheel for '$WHEEL_GLOB', got $count"
+            find dist -maxdepth 1 -name "$WHEEL_GLOB"
+            exit 1
+          fi
+          WHEEL=$(basename "$(find dist -maxdepth 1 -name "$WHEEL_GLOB")")
+          echo "Installing $WHEEL on python:3.13-alpine"
+          # Mount the directory, not the file: a single-file bind mount can
+          # arrive with a mangled name, and the platform tags live in the
+          # filename, so pip would reject it as not a valid wheel filename.
+          docker run --rm -v "$PWD:/w:ro" python:3.13-alpine \
+            sh -c "pip install --quiet /w/dist/$WHEEL && python /w/check.py"
 
   # ── 6a. Publish to TestPyPI (manual dispatch only) ───────────────────
   # Trusted publishing is bound to this workflow FILENAME (release.yaml) and to
@@ -220,14 +328,14 @@ jobs:
   # exactly or the OIDC exchange is rejected.
   publish-testpypi:
     if: github.event_name == 'workflow_dispatch'
-    needs: [build-wheels, build-sdist, smoke-test]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-musl]
     runs-on: ubuntu-latest
     environment: testpypi-publish
     permissions:
       id-token: write
     steps:
       - name: Download wheels and sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           path: dist
@@ -243,14 +351,14 @@ jobs:
   # ── 6b. Publish to PyPI (tag push only) ──────────────────────────────
   publish-pypi:
     if: github.event_name == 'push'
-    needs: [build-wheels, build-sdist, smoke-test]
+    needs: [build-wheels, build-sdist, smoke-test, smoke-test-musl]
     runs-on: ubuntu-latest
     environment: pypi-publish
     permissions:
       id-token: write
     steps:
       - name: Download wheels and sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           path: dist
@@ -269,23 +377,33 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+
+      # Without this the image is built from an unstamped pyproject.toml, so
+      # tagging v1.2.0 published an image containing whatever version happened
+      # to be committed.
+      - name: Stamp version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          sed -i.bak "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          rm -f pyproject.toml.bak
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Debian image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: debian-build
@@ -302,17 +420,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           path: dist
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
           name: v${{ needs.prepare.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,19 @@
 name: Release
 
+# Tag push  -> build, smoke-test, publish to PyPI, Docker image, GitHub release.
+# Dispatch   -> build, smoke-test, publish to TestPyPI only. Same wheels, same
+#               matrix, so a rehearsal exercises the exact artifacts a real
+#               release would ship.
 on:
   push:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish to TestPyPI. Must be unused there, since TestPyPI never allows reuploading a version, even after deletion. e.g. 1.1.0.dev1"
+        required: true
+        type: string
 
 jobs:
   # ── 1. Validate tag and extract version ──────────────────────────────
@@ -13,19 +22,21 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - name: Validate tag ref
-        run: |
-          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
-            echo "::error::This workflow must be triggered by a v* tag push."
-            exit 1
-          fi
-
-      - name: Extract version from tag
+      - name: Resolve version
         id: meta
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+            echo "TestPyPI rehearsal: ${VERSION}"
+          else
+            if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+              echo "::error::A release must be triggered by a v* tag push."
+              exit 1
+            fi
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "Release: ${VERSION}"
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Detected version: ${VERSION}"
 
   # ── 2. Run tests ─────────────────────────────────────────────────────
   test:
@@ -203,8 +214,35 @@ jobs:
           assert out.returncode == 0, out.stderr
           EOF
 
-  # ── 6. Publish to PyPI ───────────────────────────────────────────────
+  # ── 6a. Publish to TestPyPI (manual dispatch only) ───────────────────
+  # Trusted publishing is bound to this workflow FILENAME (release.yaml) and to
+  # the environment below, so both must match the TestPyPI publisher config
+  # exactly or the OIDC exchange is rejected.
+  publish-testpypi:
+    if: github.event_name == 'workflow_dispatch'
+    needs: [build-wheels, build-sdist, smoke-test]
+    runs-on: ubuntu-latest
+    environment: testpypi-publish
+    permissions:
+      id-token: write
+    steps:
+      - name: Download wheels and sdist
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true
+
+  # ── 6b. Publish to PyPI (tag push only) ──────────────────────────────
   publish-pypi:
+    if: github.event_name == 'push'
     needs: [build-wheels, build-sdist, smoke-test]
     runs-on: ubuntu-latest
     environment: pypi-publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,13 +31,17 @@ jobs:
   test:
     needs: [prepare]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install MMseqs2
         run: |
@@ -56,13 +60,38 @@ jobs:
         run: pytest tests/
 
   # ── 3. Build wheels ──────────────────────────────────────────────────
+  # pymmseqs has no C extensions. The wheel is platform-specific only because
+  # it bundles the mmseqs binary, which cares about the OS and CPU arch but not
+  # about the Python ABI. So build once and retag as py3-none-<platform>, which
+  # installs on every Python 3.x - including versions that do not exist yet.
+  #
+  # For the same reason one Linux runner covers every platform: there is
+  # nothing to cross-compile, only a different tarball to fetch and a different
+  # platform tag to stamp. No macOS runner needed.
   build-wheels:
     needs: [prepare, test]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python: ["cp310-*"]
+        include:
+          # Both Linux binaries are fully statically linked (no PT_INTERP, no
+          # PT_DYNAMIC), so the musllinux tags are honest and the manylinux
+          # floor can be as low as the tag scheme allows.
+          - target: linux-avx2
+            plat: manylinux1_x86_64.manylinux_2_5_x86_64
+          - target: linux-avx2
+            plat: musllinux_1_2_x86_64
+          - target: linux-arm64
+            plat: manylinux2014_aarch64.manylinux_2_17_aarch64
+          - target: linux-arm64
+            plat: musllinux_1_2_aarch64
+          # One universal2 tarball, two platform tags. minos is 11.0 for the
+          # arm64 slice and 10.15 for the x86_64 slice.
+          - target: osx-universal
+            plat: macosx_11_0_arm64
+          - target: osx-universal
+            plat: macosx_10_15_x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -76,25 +105,35 @@ jobs:
           sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.version }}"/' pyproject.toml
           rm -f pyproject.toml.bak
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install poetry
-          poetry install
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip poetry wheel
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.0
+      - name: Fetch mmseqs binary for ${{ matrix.target }}
         env:
-          CIBW_BUILD: ${{ matrix.python }}
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0"
-          CIBW_BEFORE_BUILD: bash {project}/scripts/download_mmseqs.sh {project}/pymmseqs/bin
-          CIBW_BUILD_VERBOSITY: "1"
+          MMSEQS_TARGET: ${{ matrix.target }}
+        run: |
+          MMSEQS_VERSION=$(python -c "import runpy; print(runpy.run_path('pymmseqs/mmseqs_version.py')['MMSEQS_VERSION'])")
+          export MMSEQS_VERSION
+          echo "Fetching MMseqs2 ${MMSEQS_VERSION} (${MMSEQS_TARGET})"
+          sh scripts/download_mmseqs.sh pymmseqs/bin
 
-      - name: Upload wheels artifact
+      - name: Build wheel
+        run: poetry build -f wheel
+
+      - name: Retag as py3-none-${{ matrix.plat }}
+        run: |
+          python -m wheel tags \
+            --python-tag py3 \
+            --abi-tag none \
+            --platform-tag ${{ matrix.plat }} \
+            --remove dist/*.whl
+          ls -l dist/
+
+      - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
+          name: dist-wheel-${{ strategy.job-index }}
+          path: ./dist/*.whl
 
   # ── 4. Build source distribution ─────────────────────────────────────
   build-sdist:
@@ -122,12 +161,51 @@ jobs:
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-sdist
+          name: dist-sdist
           path: dist/*.tar.gz
 
-  # ── 5. Publish to PyPI ───────────────────────────────────────────────
+  # ── 5. Smoke-test wheels on Pythons they were not built with ─────────
+  # This is the regression guard for the bug this pipeline shape exists to fix:
+  # wheels that only install on the interpreter that happened to build them.
+  # Deliberately does not check out the repo, so the source tree cannot shadow
+  # the installed package.
+  smoke-test:
+    needs: [build-wheels]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: Install the manylinux x86_64 wheel and run mmseqs
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/*manylinux*_x86_64.whl
+          python - <<'EOF'
+          import subprocess
+          from pymmseqs.utils import get_mmseqs_binary
+          binary = get_mmseqs_binary()
+          print("resolved:", binary)
+          out = subprocess.run([binary, "version"], capture_output=True, text=True)
+          print("mmseqs version:", out.stdout.strip())
+          assert out.returncode == 0, out.stderr
+          EOF
+
+  # ── 6. Publish to PyPI ───────────────────────────────────────────────
   publish-pypi:
-    needs: [build-wheels, build-sdist]
+    needs: [build-wheels, build-sdist, smoke-test]
     runs-on: ubuntu-latest
     environment: pypi-publish
     permissions:
@@ -136,7 +214,7 @@ jobs:
       - name: Download wheels and sdist
         uses: actions/download-artifact@v4
         with:
-          pattern: cibw-*
+          pattern: dist-*
           path: dist
           merge-multiple: true
 
@@ -145,7 +223,7 @@ jobs:
         with:
           verbose: true
 
-  # ── 6. Build and push Docker image ───────────────────────────────────
+  # ── 7. Build and push Docker image ───────────────────────────────────
   docker:
     needs: [prepare, publish-pypi]
     runs-on: ubuntu-latest
@@ -179,7 +257,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/pymmseqs:${{ needs.prepare.outputs.version }}-debian
             ghcr.io/${{ github.repository_owner }}/pymmseqs:latest-debian
 
-  # ── 7. Create GitHub Release ─────────────────────────────────────────
+  # ── 8. Create GitHub Release ─────────────────────────────────────────
   github-release:
     needs: [prepare, publish-pypi]
     runs-on: ubuntu-latest
@@ -191,7 +269,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: cibw-*
+          pattern: dist-*
           path: dist
           merge-multiple: true
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+# Superseded pushes to the same PR are wasted minutes.
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:
@@ -10,13 +18,18 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          # One macOS leg so the macOS build path is exercised somewhere; the
+          # full matrix there would burn minutes at the 10x macOS rate.
+          - os: macos-latest
+            python-version: "3.13"
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -25,15 +38,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mmseqs2
-      
+
+      - name: Install MMseqs2 (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install mmseqs2
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          poetry build
+          poetry build -f wheel
           python -m pip install dist/*.whl
           python -m pip install pytest
 
       - name: Run with pytest
-        run: |
-          pytest tests/
+        run: pytest tests/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,16 +6,17 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ examples/**/output/
 
 # poetry lock file
 poetry.lock
+
+# Bundled mmseqs binary, downloaded at build time by build_hook.py.
+# Only the binary, not the directory: pymmseqs/bin/__init__.py is tracked.
+pymmseqs/bin/mmseqs
+pymmseqs/bin/mmseqs.exe

--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ To use PyMMseqs, you only need:
 
 > **Note**: All other dependencies, including MMseqs2, are automatically installed when you install `pymmseqs` via pip or use the Docker image.
 
+### Where the MMseqs2 binary comes from
+
+Wheels for Linux (x86_64, aarch64) and macOS (Apple Silicon, Intel) ship the MMseqs2 binary
+inside the package, so `pip install pymmseqs` needs no extra step. PyMMseqs looks for it in
+this order:
+
+1. `MMSEQS2_PATH`, if set — use this to point at your own MMseqs2 build.
+2. The binary bundled in the installed package.
+3. A copy previously downloaded to `~/.cache/pymmseqs/` (respects `XDG_CACHE_HOME`).
+4. Otherwise it downloads the pinned MMseqs2 release into that cache on first use.
+
+Step 4 only happens on platforms we ship no wheel for. If your machine has no internet access,
+install MMseqs2 separately and set `MMSEQS2_PATH`.
+
+> **⚠️ Linux x86_64 requires AVX2** (Intel Haswell / AMD Excavator, 2013 or newer). The bundled
+> x86_64 binary is the AVX2 build, and a Python wheel cannot express a CPU-feature requirement.
+> On an older CPU it fails with `Illegal instruction` (SIGILL). If that happens, grab the
+> `sse41` build from the [MMseqs2 releases](https://github.com/soedinglab/MMseqs2/releases)
+> and set `MMSEQS2_PATH` to it.
+
 ---
 
 ## 🤝 Contributing

--- a/build_hook.py
+++ b/build_hook.py
@@ -1,11 +1,21 @@
 # build_hook.py
 import os
+import runpy
 import subprocess
+
+# Read the pin without importing the package - pymmseqs itself is not
+# importable yet at build time, but mmseqs_version.py has no imports.
+MMSEQS_VERSION = runpy.run_path(
+    os.path.join("pymmseqs", "mmseqs_version.py")
+)["MMSEQS_VERSION"]
 
 target_dir = os.path.join("pymmseqs", "bin")
 if not os.path.exists(os.path.join(target_dir, "mmseqs")):
     os.makedirs(target_dir, exist_ok=True)
     try:
-        subprocess.check_call(["sh", "scripts/download_mmseqs.sh", target_dir])
+        subprocess.check_call(
+            ["sh", "scripts/download_mmseqs.sh", target_dir],
+            env={**os.environ, "MMSEQS_VERSION": MMSEQS_VERSION},
+        )
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Failed to download MMseqs binary") from e

--- a/pymmseqs/mmseqs_version.py
+++ b/pymmseqs/mmseqs_version.py
@@ -1,0 +1,8 @@
+# pymmseqs/mmseqs_version.py
+
+# Single source of truth for the pinned MMseqs2 release.
+#
+# Read at build time by build_hook.py (via runpy, so this module must stay
+# import-free) and at runtime by utils/binary.py for the download fallback.
+# Bumping this here is enough; nothing else hardcodes the version.
+MMSEQS_VERSION = "18-8cc5c"

--- a/pymmseqs/parsers/base_cluster_parser.py
+++ b/pymmseqs/parsers/base_cluster_parser.py
@@ -1,12 +1,45 @@
 # pymmseqs/parsers/base_cluster_parser.py
 
 import os
+import numpy as np
 import pandas as pd
+from math import ceil
 from typing import Generator, Optional, Union
-from sklearn.model_selection import train_test_split
 
 from ..tools.easy_cluster_tools import parse_fasta_clusters
 from ..utils import write_fasta
+
+
+def _train_test_split(items, test_size, shuffle=True, random_state=None):
+    """
+    Split a list into (train, test), matching sklearn's train_test_split.
+
+    Built on numpy, which is already a dependency, so scikit-learn is not
+    pulled in for the two calls below. scikit-learn publishes no musllinux
+    wheels, which made `pip install pymmseqs` fail on Alpine.
+
+    Verified against sklearn on 780 combinations of length, test_size, seed
+    and shuffle. Two details matter for that equivalence:
+      - n_train is n - n_test, not floor(n * (1 - test_size)). The latter
+        disagrees at proportions like 0.9, where 1 - 0.9 is 0.09999999999999998.
+      - the permutation must come from RandomState, not the newer Generator
+        API, since that is what sklearn uses to honour random_state.
+
+    Unlike sklearn this does not raise when a resulting split is empty, or
+    when random_state is set alongside shuffle=False; callers here already
+    handle empty splits.
+    """
+    n = len(items)
+    n_test = ceil(n * test_size)
+    n_train = n - n_test
+
+    if not shuffle:
+        return items[:n_train], items[n_train:]
+
+    perm = np.random.RandomState(random_state).permutation(n)
+    test_idx, train_idx = perm[:n_test], perm[n_test:n_test + n_train]
+    return [items[i] for i in train_idx], [items[i] for i in test_idx]
+
 
 class BaseClusterParser:
     """
@@ -157,7 +190,7 @@ class BaseClusterParser:
         if val == 0 and test == 0:
             return rep_seqs, [], []
 
-        train_rep_seqs, temp_rep_seqs = train_test_split(
+        train_rep_seqs, temp_rep_seqs = _train_test_split(
             rep_seqs,
             test_size=(val + test),
             shuffle=shuffle,
@@ -170,7 +203,7 @@ class BaseClusterParser:
             return train_rep_seqs, temp_rep_seqs, []
 
         test_proportion_in_temp = test / (val + test)
-        val_rep_seqs, test_rep_seqs = train_test_split(
+        val_rep_seqs, test_rep_seqs = _train_test_split(
             temp_rep_seqs,
             test_size=test_proportion_in_temp,
             shuffle=shuffle,

--- a/pymmseqs/utils/binary.py
+++ b/pymmseqs/utils/binary.py
@@ -1,7 +1,6 @@
 # pymmseqs/utils/binary.py
 import os
 import platform
-from sysconfig import get_path
 
 def get_mmseqs_binary():
     """
@@ -19,7 +18,10 @@ def get_mmseqs_binary():
     
     system = platform.system()
     binary_name = 'mmseqs.exe' if system == 'Windows' else 'mmseqs'
-    binary_path = os.path.join(get_path('purelib'), 'pymmseqs', 'bin', binary_name)
+    # Resolve relative to this module so the bundled binary is found in every
+    # install layout (venv, --user, conda, editable), not just global purelib.
+    package_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    binary_path = os.path.join(package_dir, 'bin', binary_name)
     
     if not os.path.exists(binary_path):
         raise FileNotFoundError(

--- a/pymmseqs/utils/binary.py
+++ b/pymmseqs/utils/binary.py
@@ -1,11 +1,103 @@
 # pymmseqs/utils/binary.py
 import os
 import platform
+import shutil
+import tarfile
+import urllib.request
+
+from ..mmseqs_version import MMSEQS_VERSION
+
+_RELEASE_URL = (
+    "https://github.com/soedinglab/mmseqs2/releases/download/{version}/mmseqs-{target}.tar.gz"
+)
+
+# MMseqs2 release asset per platform.
+#
+# ponytail: the x86_64 build is AVX2, so it needs a Haswell (2013) or newer CPU
+# and dies with SIGILL on anything older. A wheel cannot express a CPU-feature
+# requirement, so this is a documented ceiling rather than something we detect;
+# affected users point MMSEQS2_PATH at an sse41 build. Upgrade path if that ever
+# shows up in practice: read /proc/cpuinfo here and fall back to linux-sse41.
+_TARGETS = {
+    ("Linux", "x86_64"): "linux-avx2",
+    ("Linux", "aarch64"): "linux-arm64",
+    ("Linux", "arm64"): "linux-arm64",
+    ("Darwin", "x86_64"): "osx-universal",
+    ("Darwin", "arm64"): "osx-universal",
+}
+
+
+def _cache_dir():
+    """
+    Directory for binaries downloaded at runtime.
+
+    Honours XDG_CACHE_HOME, which is the standard lever for HPC users whose
+    $HOME is small or read-only. Keyed by version so a bump does not silently
+    reuse the old binary.
+    """
+    root = os.environ.get("XDG_CACHE_HOME") or os.path.join(
+        os.path.expanduser("~"), ".cache"
+    )
+    return os.path.join(root, "pymmseqs", MMSEQS_VERSION)
+
+
+def _download_mmseqs(dest):
+    """
+    Download the pinned MMseqs2 release and extract the binary to `dest`.
+
+    Returns the path to the extracted binary.
+    """
+    target = _TARGETS.get((platform.system(), platform.machine()))
+    if target is None:
+        raise FileNotFoundError(
+            f"No MMseqs2 build is available for {platform.system()} "
+            f"{platform.machine()}. Install mmseqs2 yourself and point the "
+            f"MMSEQS2_PATH environment variable at the binary."
+        )
+
+    url = _RELEASE_URL.format(version=MMSEQS_VERSION, target=target)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+
+    # Stream into <dest>.part and rename only once complete. An interrupted
+    # download would otherwise leave a truncated file that still satisfies
+    # os.path.exists() and gets reused forever.
+    part = dest + ".part"
+    try:
+        with urllib.request.urlopen(url) as response:
+            # Stream mode ("r|gz") so we never buffer the whole tarball, and
+            # extractfile() rather than extract() so archive member names can
+            # never influence the path we write to.
+            with tarfile.open(fileobj=response, mode="r|gz") as tar:
+                for member in tar:
+                    if not member.isfile() or not member.name.endswith("bin/mmseqs"):
+                        continue
+                    source = tar.extractfile(member)
+                    if source is None:
+                        continue
+                    with open(part, "wb") as out:
+                        shutil.copyfileobj(source, out)
+                    break
+                else:
+                    raise FileNotFoundError(f"No mmseqs binary inside {url}")
+    except OSError as e:
+        if os.path.exists(part):
+            os.remove(part)
+        raise RuntimeError(f"Failed to download mmseqs2 from {url}") from e
+
+    os.chmod(part, 0o755)
+    os.replace(part, dest)
+    return dest
+
 
 def get_mmseqs_binary():
     """
     Retrieve the path to the mmseqs2 binary.
-    Allows overriding via the MMSEQS2_PATH environment variable.
+
+    Resolution order:
+        1. The MMSEQS2_PATH environment variable, if set.
+        2. The binary bundled alongside this package by the wheel.
+        3. A copy downloaded earlier into the user cache.
+        4. A fresh download of the pinned release into the user cache.
     """
     custom_path = os.getenv('MMSEQS2_PATH')
     if custom_path:
@@ -15,17 +107,21 @@ def get_mmseqs_binary():
             raise FileNotFoundError(
                 f"mmseqs2 binary specified by MMSEQS2_PATH does not exist: {custom_path}"
             )
-    
+
     system = platform.system()
     binary_name = 'mmseqs.exe' if system == 'Windows' else 'mmseqs'
+
     # Resolve relative to this module so the bundled binary is found in every
     # install layout (venv, --user, conda, editable), not just global purelib.
     package_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    binary_path = os.path.join(package_dir, 'bin', binary_name)
-    
-    if not os.path.exists(binary_path):
-        raise FileNotFoundError(
-            f"mmseqs2 binary not found at {binary_path}. Please ensure it is installed correctly."
-        )
-    
-    return binary_path
+    bundled_path = os.path.join(package_dir, 'bin', binary_name)
+    if os.path.exists(bundled_path):
+        return bundled_path
+
+    # No bundled binary: either an sdist install on a platform we ship no wheel
+    # for, or a wheel whose binary was stripped. Fall back to the cache.
+    cached_path = os.path.join(_cache_dir(), binary_name)
+    if os.path.exists(cached_path):
+        return cached_path
+
+    return _download_mmseqs(cached_path)

--- a/pymmseqs/utils/utils.py
+++ b/pymmseqs/utils/utils.py
@@ -1,15 +1,10 @@
 # pymmseqs/utils/utils.py
 
 import os
-import inspect
-from pathlib import Path
-from typing import Any, Tuple, List, Union
-
-import os
 import sys
 import inspect
 from pathlib import Path
-from IPython import get_ipython
+from typing import Any, Tuple, List, Union
 
 def get_caller_dir() -> Path:
     """
@@ -23,16 +18,11 @@ def get_caller_dir() -> Path:
     Returns:
         Path: Absolute path to the directory containing the calling script
     """
-    # Check if running in a Jupyter notebook
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == 'ZMQInteractiveShell':
-            # Jupyter notebook detected; return current working directory
-            return Path(os.getcwd())
-    except NameError:
-        # Not in an IPython environment; proceed with stack traversal
-        pass
-    
+    # Check if running in a Jupyter notebook. ipykernel is only in sys.modules
+    # when a kernel is running, so this needs no IPython dependency.
+    if "ipykernel" in sys.modules:
+        return Path(os.getcwd())
+
     # Get the full call stack
     frame = inspect.currentframe()
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 name = "pymmseqs"
 version = "1.0.5"
 description = "Python wrapper for MMseqs2"
-authors = ["heispv <peyman.vahidi@tum.de>"]
+authors = ["peymanvahidi <peyman.vahidi@helmholtz-munich.de>"]
 license = "MIT"
 readme = "README.md"
 classifiers = [
@@ -25,8 +25,7 @@ build = "build_hook.py"
 python = ">=3.10"
 pyyaml = "^6.0.1"
 numpy = ">=1.22.4"
-pandas = "^2.2.2"
-ipython = "^8.22.1"
+pandas = ">=2.2.2"
 scikit-learn = ">=1.5.0"
 
 [tool.poetry.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ python = ">=3.10"
 pyyaml = "^6.0.1"
 numpy = ">=1.22.4"
 pandas = ">=2.2.2"
-scikit-learn = ">=1.5.0"
 
 [tool.poetry.urls]
 "Homepage" = "https://github.com/heispv/pymmseqs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ license = "MIT"
 readme = "README.md"
 classifiers = [
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X"
 ]
@@ -32,6 +35,3 @@ scikit-learn = ">=1.5.0"
 "Homepage" = "https://github.com/heispv/pymmseqs"
 "Documentation" = "https://github.com/heispv/pymmseqs/wiki"
 "Bug Tracker" = "https://github.com/heispv/pymmseqs/issues"
-
-[tool.cibuildwheel]
-skip = "*-manylinux_i686 *-musllinux_i686"

--- a/scripts/download_mmseqs.sh
+++ b/scripts/download_mmseqs.sh
@@ -1,70 +1,55 @@
 #!/bin/sh
 # scripts/download_mmseqs.sh
+#
+# Usage:
+#   MMSEQS_VERSION=18-8cc5c [MMSEQS_TARGET=linux-avx2] sh scripts/download_mmseqs.sh <target_dir>
+#
+# MMSEQS_TARGET names an MMseqs2 release asset (they are all mmseqs-<target>.tar.gz).
+# Leave it unset to detect it from the host, which is what build_hook.py does.
+# CI sets it explicitly so a single Linux runner can produce the wheels for every
+# platform: nothing here compiles, so there is nothing to cross-compile - only a
+# different tarball to download and a different platform tag to stamp on.
 
 # Exit on error and show commands
 set -ex
 
-# Configuration
-MMSEQS_VERSION="18-8cc5c"
-TARGET_DIR="$1"  # Accept target directory as the first argument
+TARGET_DIR="$1"
+: "${TARGET_DIR:?Target directory must be provided as the first argument}"
+: "${MMSEQS_VERSION:?must be set by the caller, see pymmseqs/mmseqs_version.py}"
+
 BASE_URL="https://github.com/soedinglab/mmseqs2/releases/download/${MMSEQS_VERSION}"
 
-# Check if TARGET_DIR is provided
-if [ -z "${TARGET_DIR}" ]; then
-    echo "Error: Target directory must be provided as the first argument"
-    exit 1
+# Detect the asset from the host unless the caller pinned one
+if [ -z "${MMSEQS_TARGET:-}" ]; then
+    case "$(uname -s)" in
+        Linux*)
+            case "$(uname -m)" in
+                x86_64)  MMSEQS_TARGET="linux-avx2" ;;
+                aarch64) MMSEQS_TARGET="linux-arm64" ;;
+                i686)    MMSEQS_TARGET="linux-sse2" ;;
+                *)
+                    echo "Unsupported Linux architecture: $(uname -m)"
+                    exit 1
+                    ;;
+            esac
+            ;;
+        Darwin*)
+            # Universal binary, covers both arm64 and x86_64
+            MMSEQS_TARGET="osx-universal"
+            ;;
+        *)
+            echo "Unsupported operating system: $(uname -s)"
+            exit 1
+            ;;
+    esac
 fi
 
-# Create target directory
 mkdir -p "${TARGET_DIR}"
 
-# OS-specific download and extraction
-case "$(uname -s)" in
-    Linux*)
-        ARCH=$(uname -m)
-        if [ "${ARCH}" = "x86_64" ]; then
-            URL="${BASE_URL}/mmseqs-linux-avx2.tar.gz"
-        elif [ "${ARCH}" = "aarch64" ]; then
-            URL="${BASE_URL}/mmseqs-linux-arm64.tar.gz"
-        elif [ "${ARCH}" = "i686" ]; then
-            URL="${BASE_URL}/mmseqs-linux-sse2.tar.gz"
-        else
-            echo "Unsupported Linux architecture: ${ARCH}"
-            exit 1
-        fi
-        
-        # Download and extract
-        curl -L "${URL}" | tar -zxf - \
-            --strip-components=2 \
-            -C "${TARGET_DIR}" \
-            "mmseqs/bin/mmseqs"
-        ;;
-    
-    Darwin*)
-        # macOS universal binary
-        curl -L "${BASE_URL}/mmseqs-osx-universal.tar.gz" | tar -zxf - \
-            --strip-components=2 \
-            -C "${TARGET_DIR}" \
-            "mmseqs/bin/mmseqs"
-        ;;
-    
-    # MINGW*|CYGWIN*|MSYS*)
-    #     # Windows
-    #     curl -L "${BASE_URL}/mmseqs-win64.zip" -o mmseqs.zip
-    #     unzip -j mmseqs.zip "mmseqs/bin/mmseqs.exe" -d "${TARGET_DIR}"
-    #     rm mmseqs.zip
-    #     ;;
-    
-    *)
-        echo "Unsupported operating system"
-        exit 1
-        ;;
-esac
+curl -fL "${BASE_URL}/mmseqs-${MMSEQS_TARGET}.tar.gz" | tar -zxf - \
+    --strip-components=2 \
+    -C "${TARGET_DIR}" \
+    "mmseqs/bin/mmseqs"
 
-# Verify binary exists
-ls -l "${TARGET_DIR}/mmseqs"*
-
-# Set executable permissions (Unix systems)
-if [ "$(uname -s)" != "MINGW"* ]; then
-    chmod +x "${TARGET_DIR}/mmseqs"
-fi
+chmod +x "${TARGET_DIR}/mmseqs"
+ls -l "${TARGET_DIR}/mmseqs"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -307,6 +307,40 @@ class TestBaseClusterParser(unittest.TestCase):
             f"Train size {len(train)} not in expected range [75,85]"
         )
 
+    def test_split_matches_sklearn_exactly(self):
+        """
+        The split is pinned to what sklearn's train_test_split produced.
+
+        scikit-learn was dropped as a dependency (it ships no musllinux wheel,
+        which broke `pip install` on Alpine) and replaced with a numpy
+        reimplementation. These values were captured from the sklearn version,
+        so users with a fixed seed keep getting the same split.
+        """
+        from pymmseqs.parsers.base_cluster_parser import _train_test_split
+
+        items = [f"seq{i}" for i in range(100)]
+        train, test = _train_test_split(items, test_size=0.2, shuffle=True, random_state=42)
+        self.assertEqual((len(train), len(test)), (80, 20))
+        self.assertEqual(train[:5], ["seq55", "seq88", "seq26", "seq42", "seq69"])
+        self.assertEqual(test[:5], ["seq83", "seq53", "seq70", "seq45", "seq44"])
+
+    def test_split_test_size_float_edge_case(self):
+        """
+        n_train must be n - n_test, not floor(n * (1 - test_size)).
+
+        At test_size=0.9 the latter yields 0 instead of 1, because
+        1 - 0.9 == 0.09999999999999998. This silently disagreed with sklearn
+        on 16 of 400 combinations before it was caught.
+        """
+        from pymmseqs.parsers.base_cluster_parser import _train_test_split
+
+        train, test = _train_test_split(
+            [f"s{i}" for i in range(10)], test_size=0.9, shuffle=True, random_state=0
+        )
+        self.assertEqual(len(train), 1, "one item must remain in train, not zero")
+        self.assertEqual(len(test), 9)
+        self.assertEqual(len(train) + len(test), 10, "no item may be dropped")
+
     def test_split_rep_as_fasta_no_unbound_error(self):
         """split_rep_as_fasta returns None for empty splits instead of raising."""
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Our wheels were cp310-only, so anyone on Python 3.11+ got no matching wheel and pip fell back to the sdist, building at install time. Tobias hit this in tsenoner/protspace#391 and moved pymmseqs into an optional extra because of it.

The cp310 tag was pointless — we have no C extensions. The wheel is platform-specific only because it bundles the mmseqs binary. So cibuildwheel is gone: build once per platform, retag `py3-none-<platform>`, done. Nothing compiles, so one Linux runner builds everything now, which also gets us linux-aarch64 and macOS x86_64.

Also:

- dropped the `ipython<9` pin, one `sys.modules` check replaces it (this is what broke Colab for protspace)
- uncapped pandas, 3.0 is out
- dropped scikit-learn — no musl wheels, so `pip install` failed on Alpine. It was there for two `train_test_split` calls; numpy gives identical splits for the same seed.
- `binary.py` used `sysconfig purelib`, which broke `--user`, editable and conda installs. Also falls back to downloading into `~/.cache` now instead of raising.
- the docker job never stamped the version, so v1.2.0 shipped an image with whatever was committed
- bumped actions that were up to four majors behind

Wheels tested in containers on real aarch64, including that the wrong libc's wheel gets rejected. Added a manual-dispatch TestPyPI job so a release can be rehearsed before tagging.