### PR TITLE
Fix wheels shipping without the mmseqs binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -260,10 +260,21 @@ jobs:
           echo "Installing $WHEEL on $(python -V)"
           python -m pip install "$WHEEL"
           python - <<'PY'
-          import subprocess
+          import pathlib, subprocess
+          import pymmseqs
           from pymmseqs.utils import get_mmseqs_binary
+
+          # Assert the binary came from the WHEEL, not the runtime download
+          # fallback. Without this the fallback silently rescues an empty wheel
+          # and the smoke test passes on a broken release - which is exactly
+          # what happened when a .gitignore entry emptied every wheel.
+          bundled = pathlib.Path(pymmseqs.__file__).parent / "bin" / "mmseqs"
+          assert bundled.exists(), f"wheel shipped no binary at {bundled}"
+
           binary = get_mmseqs_binary()
-          print("resolved:", binary)
+          print("resolved:", binary, f"({bundled.stat().st_size:,} bytes)")
+          assert pathlib.Path(binary) == bundled, f"resolved {binary}, expected {bundled}"
+
           out = subprocess.run([binary, "version"], capture_output=True, text=True)
           print("mmseqs version:", out.stdout.strip())
           assert out.returncode == 0, out.stderr
@@ -295,10 +306,18 @@ jobs:
       - name: Write check script
         run: |
           cat > check.py <<'PY'
-          import subprocess
+          import pathlib, subprocess
+          import pymmseqs
           from pymmseqs.utils import get_mmseqs_binary
+
+          # Must come from the wheel, not the runtime download fallback.
+          bundled = pathlib.Path(pymmseqs.__file__).parent / "bin" / "mmseqs"
+          assert bundled.exists(), f"wheel shipped no binary at {bundled}"
+
           binary = get_mmseqs_binary()
-          print("resolved:", binary)
+          print("resolved:", binary, f"({bundled.stat().st_size:,} bytes)")
+          assert pathlib.Path(binary) == bundled, f"resolved {binary}, expected {bundled}"
+
           out = subprocess.run([binary, "version"], capture_output=True, text=True)
           print("mmseqs version:", out.stdout.strip())
           assert out.returncode == 0, out.stderr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X"
 ]
 include = [
-    "pymmseqs/bin/*",
+    # Dict form, because the binary is gitignored and poetry drops VCS-ignored
+    # files from the package - the plain string form silently produced 160 KB
+    # wheels with no binary in them.
+    #
+    # Wheel only: an sdist must stay platform-neutral. If it carried a binary,
+    # build_hook.py would skip the download and, say, a macOS binary could end
+    # up installed on Linux.
+    { path = "pymmseqs/bin/*", format = ["wheel"] },
     "pymmseqs/defaults/*.yaml",
     "scripts/*"
 ]


### PR DESCRIPTION
The TestPyPI rehearsal caught this before it reached PyPI: every published wheel was 160 KB instead of ~7 MB, with no mmseqs binary inside.

Cause was the `.gitignore` entry I added for `pymmseqs/bin/mmseqs` in #27 — poetry drops VCS-ignored files from the package even when `include` lists them explicitly. The dict form of `include` overrides that. I scoped it to `wheel` only, since an sdist carrying a binary would make `build_hook` skip its download and could put a macOS binary into a Linux install.

The more annoying part is that CI didn't notice. The runtime download fallback quietly fetched the binary into `~/.cache`, so all five smoke tests passed against a completely broken release. Smoke tests now assert the binary actually came from the wheel — verified that this fails against the broken 1.2.0.dev1 currently on TestPyPI and passes against a fixed build.